### PR TITLE
Fixes rendering of "0" values

### DIFF
--- a/t.js
+++ b/t.js
@@ -37,7 +37,7 @@
 			}
 			vars = vars[parts.shift()];
 		}
-		return vars;
+		return typeof(vars) === 'function' : vars() : vars;
 	}
 
 	function render(fragment, vars) {


### PR DESCRIPTION
`{{=age}}` with `{ age: 0 }` will render "0"
`{{=name}}` with `{ name: false }` will render "false"
`{{=name}}` with `{ name: null }` or `{}` will render ""
