### PR TITLE
adding support for AMD, CommonJs or global browser space

### DIFF
--- a/t.js
+++ b/t.js
@@ -26,7 +26,7 @@
 	}
 
 	function scrub(val) {
-		return new Option(val).innerHTML.replace(/"/g,"&quot;");
+		return new Option(val).text.replace(/"/g,"&quot;");
 	}
 
 	function get_value(vars, key) {

--- a/t.js
+++ b/t.js
@@ -98,6 +98,14 @@
 		return render(this.t, vars);
 	};
 
-	window.t = t;
-
-})();
+	//AMD, CommonJs, then globals
+  if (typeof window.define === 'function' && window.define.amd) {
+    window.define([], function(){
+      return t;
+    });
+  } else if (typeof exports === 'object') {
+    module.exports = t;
+  } else {
+    window.t = window.t || t;
+  }
+}());

--- a/t.js
+++ b/t.js
@@ -99,8 +99,8 @@
 	};
 
 	//AMD, CommonJs, then globals
-  if (typeof window.define === 'function' && window.define.amd) {
-    window.define([], function(){
+  if (typeof define === 'function' && define.amd) {
+    define([], function() {
       return t;
     });
   } else if (typeof exports === 'object') {

--- a/t.min.js
+++ b/t.min.js
@@ -1,9 +1,9 @@
 !function(){function n(n){this.t=n}function t(n){return new Option(n).text.replace(/"/g,"&quot;")}function e(n,t){for(var e=t.split(".");e.length;){if(!(e[0]in n))return!1
-n=n[e.shift()]}return n}function r(n,f){return n.replace(i,function(n,t,i,o,u,c,a,p){var w,d=e(f,o),l=""
-if(!d)return"!"==i?r(u,f):a?r(p,f):""
+n=n[e.shift()]}return n}function r(n,f){return n.replace(i,function(n,t,i,o,u,c,a,p){var l,s=e(f,o),d=""
+if(!s)return"!"==i?r(u,f):a?r(p,f):""
 if(!i)return r(c,f)
 if("@"==i){n=f._key,t=f._val
-for(w in d)d.hasOwnProperty(w)&&(f._key=w,f._val=d[w],l+=r(u,f))
-return f._key=n,f._val=t,l}}).replace(o,function(n,r,i){var o=e(f,i)
+for(l in s)s.hasOwnProperty(l)&&(f._key=l,f._val=s[l],d+=r(u,f))
+return f._key=n,f._val=t,d}}).replace(o,function(n,r,i){var o=e(f,i)
 return o||0===o?"%"==r?t(o):o:""})}var i=/\{\{(([@!]?)(.+?))\}\}(([\s\S]+?)(\{\{:\1\}\}([\s\S]+?))?)\{\{\/\1\}\}/g,o=/\{\{([=%])(.+?)\}\}/g
-n.prototype.render=function(n){return r(this.t,n)},"function"==typeof window.define&&window.define.amd?window.define([],function(){return n}):"object"==typeof exports?module.exports=n:window.t=window.t||n}()
+n.prototype.render=function(n){return r(this.t,n)},"function"==typeof define&&define.amd?define([],function(){return n}):"object"==typeof exports?module.exports=n:window.t=window.t||n}()

--- a/t.min.js
+++ b/t.min.js
@@ -1,2 +1,9 @@
-(function(){function c(a){this.t=a}function l(a,b){for(var e=b.split(".");e.length;){if(!(e[0]in a))return!1;a=a[e.shift()]}return a}function d(a,b){return a.replace(h,function(e,a,i,f,c,h,k,m){var f=l(b,f),j="",g;if(!f)return"!"==i?d(c,b):k?d(m,b):"";if(!i)return d(h,b);if("@"==i){e=b._key;a=b._val;for(g in f)f.hasOwnProperty(g)&&(b._key=g,b._val=f[g],j+=d(c,b));b._key=e;b._val=a;return j}}).replace(k,function(a,c,d){return(a=l(b,d))||0===a?"%"==c?(new Option(a)).innerHTML.replace(/"/g,"&quot;"):
-a:""})}var h=/\{\{(([@!]?)(.+?))\}\}(([\s\S]+?)(\{\{:\1\}\}([\s\S]+?))?)\{\{\/\1\}\}/g,k=/\{\{([=%])(.+?)\}\}/g;c.prototype.render=function(a){return d(this.t,a)};window.t=c})();
+!function(){function n(n){this.t=n}function t(n){return new Option(n).text.replace(/"/g,"&quot;")}function e(n,t){for(var e=t.split(".");e.length;){if(!(e[0]in n))return!1
+n=n[e.shift()]}return n}function r(n,f){return n.replace(i,function(n,t,i,o,u,c,a,p){var w,d=e(f,o),l=""
+if(!d)return"!"==i?r(u,f):a?r(p,f):""
+if(!i)return r(c,f)
+if("@"==i){n=f._key,t=f._val
+for(w in d)d.hasOwnProperty(w)&&(f._key=w,f._val=d[w],l+=r(u,f))
+return f._key=n,f._val=t,l}}).replace(o,function(n,r,i){var o=e(f,i)
+return o||0===o?"%"==r?t(o):o:""})}var i=/\{\{(([@!]?)(.+?))\}\}(([\s\S]+?)(\{\{:\1\}\}([\s\S]+?))?)\{\{\/\1\}\}/g,o=/\{\{([=%])(.+?)\}\}/g
+n.prototype.render=function(n){return r(this.t,n)},"function"==typeof window.define&&window.define.amd?window.define([],function(){return n}):"object"==typeof exports?module.exports=n:window.t=window.t||n}()


### PR DESCRIPTION
this leaves the global t variable when using the normal way but allows to use as a proper reqire.js module i.e. 

```
define(["t"], function (t) {
    return (new t("{{=data}}")).render({data: 'myData'});
}
```
